### PR TITLE
Added tests that exemplify capture semantics.

### DIFF
--- a/ObserverSet.xcodeproj/project.pbxproj
+++ b/ObserverSet.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		8E904FD01C80206600383B20 /* CaptureSemanticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E904FCF1C80206600383B20 /* CaptureSemanticsTests.swift */; };
 		C2CC54651A71D8610084E87D /* ObserverSet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C2CC54591A71D8610084E87D /* ObserverSet.framework */; };
 		C2CC546C1A71D8610084E87D /* ObserverSetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2CC546B1A71D8610084E87D /* ObserverSetTests.swift */; };
 		C2CC54761A71D8FE0084E87D /* ObserverSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2CC54751A71D8FE0084E87D /* ObserverSet.swift */; };
@@ -23,6 +24,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		8E904FCF1C80206600383B20 /* CaptureSemanticsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CaptureSemanticsTests.swift; sourceTree = "<group>"; };
 		C2CC54591A71D8610084E87D /* ObserverSet.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ObserverSet.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C2CC545D1A71D8610084E87D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C2CC54641A71D8610084E87D /* ObserverSetTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ObserverSetTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -89,6 +91,7 @@
 			isa = PBXGroup;
 			children = (
 				C2CC546B1A71D8610084E87D /* ObserverSetTests.swift */,
+				8E904FCF1C80206600383B20 /* CaptureSemanticsTests.swift */,
 				C2CC54691A71D8610084E87D /* Supporting Files */,
 			);
 			path = ObserverSetTests;
@@ -157,6 +160,8 @@
 		C2CC54501A71D8610084E87D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftMigration = 0720;
+				LastSwiftUpdateCheck = 0720;
 				LastUpgradeCheck = 0610;
 				ORGANIZATIONNAME = "Mike Ash";
 				TargetAttributes = {
@@ -217,6 +222,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C2CC546C1A71D8610084E87D /* ObserverSetTests.swift in Sources */,
+				8E904FD01C80206600383B20 /* CaptureSemanticsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -400,6 +406,7 @@
 				C2CC54711A71D8610084E87D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		C2CC54721A71D8610084E87D /* Build configuration list for PBXNativeTarget "ObserverSetTests" */ = {
 			isa = XCConfigurationList;
@@ -408,6 +415,7 @@
 				C2CC54741A71D8610084E87D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/ObserverSet/ObserverSet.swift
+++ b/ObserverSet/ObserverSet.swift
@@ -6,8 +6,7 @@
 //  Copyright (c) 2015 Mike Ash. All rights reserved.
 //
 
-import dispatch
-
+import Foundation
 
 public class ObserverSetEntry<Parameters> {
     private weak var object: AnyObject?
@@ -19,8 +18,7 @@ public class ObserverSetEntry<Parameters> {
     }
 }
 
-
-public class ObserverSet<Parameters>: Printable {
+public class ObserverSet<Parameters>: CustomStringConvertible {
     // Locking support
     
     private var queue = dispatch_queue_create("com.mikeash.ObserverSet", nil)
@@ -37,7 +35,7 @@ public class ObserverSet<Parameters>: Printable {
     public init() {}
     
     public func add<T: AnyObject>(object: T, _ f: T -> Parameters -> Void) -> ObserverSetEntry<Parameters> {
-        let entry = ObserverSetEntry<Parameters>(object: object, f: { f($0 as T) })
+        let entry = ObserverSetEntry<Parameters>(object: object, f: { f($0 as! T) })
         synchronized {
             self.entries.append(entry)
         }
@@ -72,7 +70,7 @@ public class ObserverSet<Parameters>: Printable {
     }
     
     
-    // Printable
+    // MARK: CustomStringConvertible
     
     public var description: String {
         var entries: [ObserverSetEntry<Parameters>] = []
@@ -86,9 +84,9 @@ public class ObserverSet<Parameters>: Printable {
                 ? "\(entry.f)"
                 : "\(entry.object) \(entry.f)")
         }
-        let joined = ", ".join(strings)
+        let joined = strings.joinWithSeparator(", ")
         
-        return "\(reflect(self).summary): (\(joined))"
+        return "\(Mirror(reflecting: self).description): (\(joined))"
     }
 }
 

--- a/ObserverSetTests/CaptureSemanticsTests.swift
+++ b/ObserverSetTests/CaptureSemanticsTests.swift
@@ -1,0 +1,71 @@
+//
+//  File.swift
+//  ObserverSet
+//
+//  Created by Karl Traunmüller on 26/02/16.
+//  Copyright © 2016 Mike Ash. All rights reserved.
+//
+
+import XCTest
+import ObserverSet
+
+class CaptureSemanticsTests: XCTestCase {
+    
+    class TestObservee {
+        let event = ObserverSet<Void>()
+    }
+    
+    class TestObserverThatRegistersClosure {
+        let observee = TestObservee()
+        
+        init() {
+            observee.event.add({ [weak self] () -> Void in
+                self?.foo()
+                })
+        }
+        
+        private func foo() {
+        }
+    }
+    
+    class TestObserverThatRegistersUnboundMemberFunction {
+        let observee = TestObservee()
+        
+        init() {
+            observee.event.add(self, self.dynamicType.voidHandler)
+        }
+        
+        func voidHandler() {
+        }
+    }
+    
+    class TestObserverThatRegistersBoundMemberFunction {
+        let observee = TestObservee()
+        
+        init() {
+            observee.event.add(voidHandler)
+        }
+        
+        func voidHandler() {
+        }
+    }
+    
+    func testObserverThatRegistersClosure() {
+        weak var obj: AnyObject? = TestObserverThatRegistersClosure()
+        XCTAssertNil(obj)
+    }
+    
+    func testObserverThatRegistersUnboundMemberFunction() {
+        weak var obj: AnyObject? = TestObserverThatRegistersUnboundMemberFunction()
+        XCTAssertNil(obj)
+    }
+    
+    // see also:
+    // - https://devforums.apple.com/thread/237021
+    // - https://devforums.apple.com/message/1012414#1012414
+    func testObserverThatRegistersBoundMemberFunction() {
+        weak var obj: AnyObject? = TestObserverThatRegistersBoundMemberFunction()
+        XCTAssertNotNil(obj, "Registering a bound member function may result in a strong reference cycle. Use the overload of add() that takes an observer object and an unbound member function.")
+    }
+    
+}

--- a/ObserverSetTests/ObserverSetTests.swift
+++ b/ObserverSetTests/ObserverSetTests.swift
@@ -23,10 +23,10 @@ class ObserverSetTests: XCTestCase {
         func testNotify() {
             voidObservers.notify()
             stringObservers.notify("Sup")
-            twoStringObservers.notify("hello", "world")
-            intObservers.notify(42, 43)
-            intAndStringObservers.notify(42, "hello")
-            namedParameterObservers.notify(name: "someName", count: 42)
+            twoStringObservers.notify(("hello", "world"))
+            intObservers.notify((42, 43))
+            intAndStringObservers.notify((42, "hello"))
+            namedParameterObservers.notify((name: "someName", count: 42))
         }
     }
     
@@ -41,31 +41,31 @@ class ObserverSetTests: XCTestCase {
         }
         
         deinit {
-            println("deinit!!!!")
+            print("deinit!!!!")
         }
         
         func voidSent() {
-            println("void sent")
+            print("void sent")
         }
         
         func stringChanged(s: String) {
-            println("stringChanged: " + s)
+            print("stringChanged: " + s)
         }
         
         func twoStringChanged(s1: String, s2: String) {
-            println("twoStringChanged: \(s1) \(s2)")
+            print("twoStringChanged: \(s1) \(s2)")
         }
         
         func intChanged(i: Int, j: Int) {
-            println("intChanged: \(i) \(j)")
+            print("intChanged: \(i) \(j)")
         }
         
         func intAndStringChanged(i: Int, s: String) {
-            println("intAndStringChanged: \(i) \(s)")
+            print("intAndStringChanged: \(i) \(s)")
         }
         
         func namedParameterSent(name: String, count: Int) {
-            println("Named parameters: \(name) \(count)")
+            print("Named parameters: \(name) \(count)")
         }
     }
     
@@ -73,8 +73,8 @@ class ObserverSetTests: XCTestCase {
         let observee = TestObservee()
         var obj: TestObserver? = TestObserver(observee: observee)
         
-        let token = observee.intAndStringObservers.add{ println("int and string closure: \($0) \($1)") }
-        println("intAndStringObservers: \(observee.intAndStringObservers.description)")
+        let token = observee.intAndStringObservers.add{ print("int and string closure: \($0) \($1)") }
+        print("intAndStringObservers: \(observee.intAndStringObservers.description)")
         
         observee.testNotify()
         obj = nil
@@ -82,6 +82,6 @@ class ObserverSetTests: XCTestCase {
         observee.intAndStringObservers.remove(token)
         observee.testNotify()
         
-        println("intAndStringObservers: \(observee.intAndStringObservers.description)")
+        print("intAndStringObservers: \(observee.intAndStringObservers.description)")
     }
 }


### PR DESCRIPTION
Added tests that exemplify capture semantics and highlight a potential strong reference cycle when registering a bound member function as an observer.